### PR TITLE
Add backend skeleton

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,68 @@
+# LLM Bench Backend
+
+Este diretório contém o código inicial do serviço Backend responsável por orquestrar os benchmarks do projeto **LLM Bench**.
+
+O Backend será construído em **FastAPI** e terá as seguintes responsabilidades principais:
+
+- Expor uma API REST para disparar e consultar benchmarks.
+- Registrar modelos, datasets e resultados no banco de dados.
+- Disponibilizar métricas de hardware coletadas durante a execução.
+- Servir como camada de comunicação com o Frontend.
+
+## Rotas Iniciais
+
+A API seguirá o prefixo `/api/v1` e incluirá os endpoints abaixo:
+
+| Método | Rota                           | Descrição                                               |
+|-------|--------------------------------|---------------------------------------------------------|
+| `GET` | `/api/v1/health`               | Verifica se o serviço está ativo.                       |
+| `POST`| `/api/v1/benchmarks`           | Inicia um benchmark com os parâmetros enviados.         |
+| `GET` | `/api/v1/benchmarks/{job_id}`  | Consulta o resultado de um benchmark específico.        |
+| `GET` | `/api/v1/benchmarks`           | Lista benchmarks cadastrados (filtros opcionais).       |
+| `GET` | `/api/v1/benchmarks/{job_id}/metrics` | Retorna métricas de hardware do benchmark.      |
+| `GET` | `/api/v1/models`               | Lista modelos disponíveis para teste.                   |
+| `GET` | `/api/v1/datasets`             | Lista datasets registrados.                             |
+
+### Parâmetros de Entrada (exemplo `/benchmarks`)
+
+```json
+{
+  "model_id": "gpt2",
+  "prompt": "Seu prompt aqui",
+  "task": "text-generation",
+  "max_tokens": 50,
+  "temperature": 0.7,
+  "top_p": 0.9,
+  "use_gpu": true
+}
+```
+
+### Resposta Esperada
+
+```json
+{
+  "job_id": "123e4567-e89b-12d3-a456-426614174000",
+  "model": "gpt2",
+  "task": "text-generation",
+  "duration": 1.23,
+  "tokens_generated": 50,
+  "output": "texto gerado",
+  "hardware_metrics": {
+    "cpu_usage_percent": 40.5,
+    "ram_usage_gb": 3.2,
+    "gpu_usage_percent": 70.1,
+    "vram_usage_gb": 2.0
+  }
+}
+```
+
+## Estrutura Prevista
+
+```
+backend/
+├── README.md        # Visão geral e documentação da API
+├── main.py          # Aplicação FastAPI
+└── __init__.py      # Torna o diretório um pacote Python
+```
+
+Este é apenas o início do Backend. Novas rotas e módulos serão adicionados conforme o desenvolvimento do projeto.

--- a/backend/__init__.py
+++ b/backend/__init__.py
@@ -1,0 +1,1 @@
+"""Pacote do Backend do LLM Bench."""

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,17 @@
+"""Aplicação FastAPI do Backend."""
+
+from fastapi import FastAPI
+
+app = FastAPI(title="LLM Bench Backend")
+
+
+@app.get("/api/v1/health")
+async def health() -> dict[str, str]:
+    """Endpoint de verificação de saúde."""
+    return {"status": "ok"}
+
+
+@app.post("/api/v1/benchmarks")
+async def create_benchmark() -> dict[str, str]:
+    """Endpoint placeholder para criação de benchmarks."""
+    return {"message": "benchmark criado"}


### PR DESCRIPTION
## Summary
- add initial backend folder
- describe API design and routes in new README
- provide FastAPI app with health and benchmark placeholder

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'pydantic_settings')*

------
https://chatgpt.com/codex/tasks/task_e_6841c99a69e4832a87759d2caa5069a2