### PR TITLE
Implement additional backend routes

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -66,3 +66,20 @@ backend/
 ```
 
 Este é apenas o início do Backend. Novas rotas e módulos serão adicionados conforme o desenvolvimento do projeto.
+
+## Como executar
+
+1. Instale as dependências do projeto:
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. Inicie o servidor localmente:
+
+   ```bash
+   uvicorn backend.main:app --port 8000 --reload
+   ```
+
+3. Acesse `http://localhost:8000/api/v1/health` para verificar se o serviço está ativo.
+4. Utilize as demais rotas listadas acima para criar e consultar benchmarks, modelos e datasets.

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,6 +1,13 @@
 """Aplicação FastAPI do Backend."""
 
-from fastapi import FastAPI
+from fastapi import FastAPI, HTTPException
+
+from llm_bench_local.config.settings import settings
+from llm_bench_local.persistence.crud import BenchmarkRepository
+from llm_bench_local.datasets import DatasetManager
+
+repo = BenchmarkRepository(settings.db_path)
+datasets = DatasetManager()
 
 app = FastAPI(title="LLM Bench Backend")
 
@@ -15,3 +22,39 @@ async def health() -> dict[str, str]:
 async def create_benchmark() -> dict[str, str]:
     """Endpoint placeholder para criação de benchmarks."""
     return {"message": "benchmark criado"}
+
+
+@app.get("/api/v1/benchmarks/{job_id}")
+async def get_benchmark(job_id: str):
+    """Retorna informações de um benchmark específico."""
+    bench = repo.get_benchmark(job_id)
+    if bench is None:
+        raise HTTPException(status_code=404, detail="Benchmark não encontrado")
+    return bench
+
+
+@app.get("/api/v1/benchmarks")
+async def list_benchmarks() -> list:
+    """Lista benchmarks registrados."""
+    return repo.list_benchmarks()
+
+
+@app.get("/api/v1/benchmarks/{job_id}/metrics")
+async def get_hardware_metrics(job_id: str):
+    """Retorna métricas de hardware de um benchmark."""
+    metrics = repo.get_hardware_metrics(job_id)
+    if metrics is None:
+        raise HTTPException(status_code=404, detail="Métricas não encontradas")
+    return metrics
+
+
+@app.get("/api/v1/models")
+async def get_models() -> list[str]:
+    """Lista modelos disponíveis."""
+    return settings.get_available_models()
+
+
+@app.get("/api/v1/datasets")
+async def get_datasets() -> list[str]:
+    """Lista datasets registrados."""
+    return datasets.list_datasets()

--- a/tests/integration/test_backend.py
+++ b/tests/integration/test_backend.py
@@ -1,0 +1,76 @@
+import pytest
+from fastapi.testclient import TestClient
+import backend.main as backend
+
+class DummyRepo:
+    def __init__(self):
+        self.data = {
+            "job_id": "job1",
+            "model_id": "gpt2",
+            "task": "text-generation",
+            "status": "COMPLETED",
+            "config": {},
+            "hardware_options": {},
+            "results": None,
+            "created_at": "now",
+            "updated_at": "now",
+        }
+
+    def get_benchmark(self, job_id: str):
+        if job_id == self.data["job_id"]:
+            return self.data
+        return None
+
+    def list_benchmarks(self):
+        return [self.data]
+
+    def get_hardware_metrics(self, job_id: str):
+        if job_id == self.data["job_id"]:
+            return [{"cpu_usage_percent": 10.0}]
+        return None
+
+class DummyDatasets:
+    def list_datasets(self):
+        return ["ds1"]
+
+@pytest.fixture
+def client(monkeypatch):
+    repo = DummyRepo()
+    monkeypatch.setattr(backend, "repo", repo)
+    monkeypatch.setattr(backend, "datasets", DummyDatasets())
+    monkeypatch.setattr(backend.settings, "get_available_models", lambda: ["gpt2"])
+    return TestClient(backend.app)
+
+def test_get_benchmark(client):
+    response = client.get("/api/v1/benchmarks/job1")
+    assert response.status_code == 200
+    assert response.json()["job_id"] == "job1"
+
+def test_get_benchmark_not_found(client):
+    response = client.get("/api/v1/benchmarks/unknown")
+    assert response.status_code == 404
+
+def test_list_benchmarks(client):
+    response = client.get("/api/v1/benchmarks")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+    assert response.json()[0]["job_id"] == "job1"
+
+def test_get_hardware_metrics(client):
+    response = client.get("/api/v1/benchmarks/job1/metrics")
+    assert response.status_code == 200
+    assert isinstance(response.json(), list)
+
+def test_get_hardware_metrics_not_found(client):
+    response = client.get("/api/v1/benchmarks/unknown/metrics")
+    assert response.status_code == 404
+
+def test_get_models(client):
+    response = client.get("/api/v1/models")
+    assert response.status_code == 200
+    assert response.json() == ["gpt2"]
+
+def test_get_datasets(client):
+    response = client.get("/api/v1/datasets")
+    assert response.status_code == 200
+    assert response.json() == ["ds1"]


### PR DESCRIPTION
## Summary
- expose benchmark listing and retrieval routes in backend
- add endpoints for metrics, models and datasets
- document backend usage
- add integration tests to cover backend routes

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68499eaf8160832ab95771a129ceb85b